### PR TITLE
 Replace old default credits with new

### DIFF
--- a/lib/views/help/credits.html.erb
+++ b/lib/views/help/credits.html.erb
@@ -1,93 +1,58 @@
-<% @title = "Credit where credit is due" %>
+<% @title = "Credit where credit’s due" %>
 
 <%= render :partial => 'sidebar' %>
-<div id="left_column_flip">
+<div id="left_column_flip" class="left_column_flip">
+<h1 id="credits"><%= @title %> <a href="#credits">#</a> </h1>
 
-<h1 id="credits"><%= @title%> <a href="#credits">#</a> </h1>
+<p>Alaveteli, the software that powers <%= site_name %>, is a project of <a href="https://www.mysociety.org">mySociety</a>, a UK organisation. mySociety builds websites that empower citizens to hold authorities to account. And this is one of those sites.</p>
 
 <dl>
-
-<dt id="thanks">Which people made <%= site_name %>? <a href="#thanks">#</a> </dt>
-<dd>Oh, nearly everyone (and <a href="http://www.mysociety.org/helpus">maybe you too</a>)! 
-<ul>
-<li>
-    <a href="http://www.codefornepal.org">Code for Nepal Team</a> 
-    <a href="http://www.yrtk.org">Heather Brooke</a> 
-    (<a href="http://www.guardian.co.uk/politics/2008/mar/29/houseofcommons.michaelmartin?gusrc=rss&amp;feed=worldnews">vampy!</a>) has
-    been pushing the idea of a UK FOI archive for years now.
-</li>
-<li>
-    Both Phil Rodgers and <a href="http://www.flourish.org/blog/">Francis Irving</a>
-    entered it in a mySociety competition for ideas for public interest websites to build.
-</li>
-<li>
-    <a href="http://www.mysociety.org/2006/09/27/the-mysociety-call-for-proposals-the-winner-and-runners-up/">It won</a>, 
-    and then Chris Lightfoot (<a href="http://mk.ucant.org/archives/000129.html">RIP :(</a>) 
-    thought up the wheeze of intercepting email responses to requests and
-    automatically publishing them.  
-</li>
-<li>
-    Tom Steinberg got the cash to pay for the site from
-    <a href="http://www.jrrt.org.uk/">a dead chocolate mogul</a> (<em>thank you!</em>) ...
-</li>
-<li>
-    ... so that Francis Irving, Angie Ahl, Tommy Martin, Louise Crow, Matthew Somerville
-    and Tom Steinberg could do the complex mixture of design and coding to build
-    what you see today. 
-</li>
-<li> 
-    Thanks particularly to Julian Todd (<a href="http://www.freesteel.co.uk/wpblog/">great blog!</a>), 
-    Francis Davey, and Etienne Pollard for using the site early on and giving
-    feedback (and/or legal advice!), and also to all our other users and
-    testers.  
-</li>
-<li>
-    The amazing team of volunteers who run the site, answer your support
-    emails, maintain the database of public authorities and 
-    <a href="http://www.mysociety.org/2009/10/13/behind-whatdotheyknow/">so much more</a>.
-    Thanks to John Cross, Ben Harris, Adam McGreggor, Alex Skene,
-    Richard Taylor.
-</li>
-<li>
-    Volunteers who have provided patches to the code - thanks Peter Collingbourne
-    and Tony Bowden. 
-</li>
-<li>
-    Everyone who has helped look up FOI email addresses.
-</li>
-<li>
-    We couldn't do any of this without those
-    <a href="http://www.ukcod.org.uk/UKCOD_Trustees">crazy people</a> who volunteer,
-    amongst many other things, to do the accounts and fill in our VAT return.
-</li>
-<li>
-    Finally, all the officers and servants who have answered the many requests
-    made through the site. Their diligence, patience and professionalism is
-    what has actually made the information that you see here. Thank them for
-    helping make Government more transparent.
-</li>
-</ul>
-You're all stars.
-</dd>
-
-<dt id="helpus">Can I help out? <a href="#helpus">#</a> </dt>
+<dt id="development">Development <a href="#development">#</a></dt>
 <dd>
-    <p>Yes please! We're built out of our supporters and volunteers.</p>
-    <ul>
-    <li>You can <a href="https://secure.mysociety.org/donate/">make a donation</a>. We're a registered charity.</li>
-    <li>Help people find successful requests, and monitor performance of authorities, by 
-    <a href="/categorise/play">playing the categorisation game</a>. </li>
-    <li>Find out FOI email addresses of <a href="/help/requesting#missing_body">authorities that we're missing</a>.</li>
-    <li>Write a blog post about either <%= site_name %> or an interesting request that you've
-    found. Post about it on a forum that you frequent. Tell friends about it.</li> <li>If you're
-    a programmer, get the source code for our parent project, <a href="http://alaveteli.org">Alaveteli</a>
-    and tell us about patches we can pull. It's made in Ruby on Rails.
-    <li>Read more about <a href="http://www.mysociety.org/helpus/">volunteering with mySociety</a>.
-    </ul>
+ Hearty cheers to <a href="http://alaveteli.org/">Alaveteli</a>&rsquo;s many <a href="https://github.com/mysociety/alaveteli/graphs/contributors">contributors</a>.</p>
 </dd>
 
+<dt id="helpus">How to help <a href="#helpus">#</a></dt>
+<dd>
+  <dt id="volunteer">Become a volunteer <a href="#volunteer">#</a></dt>
+  <dd>
+    <p>If you have a passion for transparency, a great deal of patience, and a bit of spare time, consider becoming one of <%= site_name %>'s volunteer admin team. Work includes user support, helping to resolve legal issues, and shaping the site’s direction, and is primarily managed via email.</p>
+    <p>In the first instance, <%= link_to 'get in touch', help_contact_path %>.</p>
+  </dd>
+
+  <dt id="donate">Make a donation <a href="#donate">#</a></dt>
+  <dd>
+    <p>mySociety, Alaveteli's parent organisation, is a charity. WhatDoTheyKnow, our most-visited Alaveteli site, costs thousands of pounds each year, for overheads such as servers, maintenance and development.</p>
+
+    <p>Your contributions, however small, really help. <a href="https://www.mysociety.org/donate/">Donate here</a>.</p>
+  </dd>
+
+  <dt id="classification">Sort things out <a href="#classification">#</a></dt>
+  <dd>
+    <p>Admin can be fun! Help people find successful requests, and monitor performance of authorities, by <a href="<%= categorise_play_path %>">playing the categorisation game</a>.</p>
+
+    <p>Or be a dear, and find out FOI email addresses of <a href="<%= help_requesting_path(:anchor => 'missing_bodies') %>">authorities that we're missing</a>.</p>
+  </dd>
+
+  <dt id="promote">Spread the word <a href="#promote">#</a></dt>
+  <dd>
+    <p>We don’t have a massive marketing budget, so word of mouth really helps.</p>
+      <ul>
+        <li>Write a blog post about <%= site_name %>, or an interesting request that you've found.</li>
+        <li>Post about the site, and what you can do with it, on a forum that you frequent.</li>
+        <li>Tell friends about it.</li>
+        <li>Let your local newspaper or community magazine know how useful we are.</li>
+        <li>Give a talk.</li>
+      </ul>
+  </dd>
+</dd>
+
+  <dt id="code">Improve our code <a href="#code">#</a></dt>
+  <dd>
+    <p>Seen something that could work better? If you're a programmer, <a href="https://github.com/mysociety/alaveteli/">get the source code</a> for our parent project, <a href="http://alaveteli.org/">Alaveteli</a> and send us a pull request. <%= site_name %> is coded in <a href="http://rubyonrails.org/">Ruby on Rails</a>.</p>
+  </dd>
+</dl>
 
 <div id="hash_link_padding"></div>
-
 
 </div>


### PR DESCRIPTION
Removes the reference to UKCOD, and some other really quite outdated text, to replace with the newer default credits page wording from the `alavetelitheme` repo.